### PR TITLE
Support decrypt legacy DES-CBC and DES-EDE3-CBC in snowflake key-pair 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1.41", features = ["rt"] }
 tokio-stream = "0.1.17"
 chrono = "0.4"
 futures = "0.3"
-pkcs8 = { version = "0.10", features = ["pem", "pkcs5", "encryption"] }
+pkcs8 = { version = "0.10", features = ["pem", "pkcs5", "encryption", "des-insecure", "3des"] }
 rsa = "0.9"
 sha2 = "0.10"
 base64 = "0.22"


### PR DESCRIPTION
The pkcs8 crate doesn't support some algorithms by default, this PR adds support
https://docs.rs/pkcs8/latest/pkcs8/#legacy-des-cbc-and-des-ede3-cbc-3des-support-optional

https://luzmo.atlassian.net/browse/LUZMO-3786