### PR TITLE
fix: add sha1-insecure feature flag for pkcs8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1.41", features = ["rt"] }
 tokio-stream = "0.1.17"
 chrono = "0.4"
 futures = "0.3"
-pkcs8 = { version = "0.10", features = ["pem", "pkcs5", "encryption", "des-insecure", "3des"] }
+pkcs8 = { version = "0.10", features = ["pem", "pkcs5", "sha1-insecure", "encryption", "des-insecure", "3des"] }
 rsa = "0.9"
 sha2 = "0.10"
 base64 = "0.22"


### PR DESCRIPTION
add support for an extra encryption schema/algorithm
https://luzmo.atlassian.net/browse/LUZMO-4003